### PR TITLE
add a Makefile to build C files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,10 +9,10 @@ OBJ = \
 all: ${OBJ} ${ALSAROOT}/midi_alsa.so
 
 ${ALSAROOT}/midi_alsa.o: ${ALSAROOT}/midi_alsa.c
-	${CC} ${CFLAGS} -fPIC -c ${ALSAROOT}/midi_alsa.c -o ${ALSAROOT}/midi_alsa.o
+	${CC} -fPIC -c ${ALSAROOT}/midi_alsa.c -o ${ALSAROOT}/midi_alsa.o ${CFLAGS}
 
 ${ALSAROOT}/midi_alsa.so: ${OBJ}
-	${CC} ${CFLAGS} -shared -o ${ALSAROOT}/midi_alsa.so ${OBJ}
+	${CC} -shared -o ${ALSAROOT}/midi_alsa.so ${OBJ} ${CFLAGS}
 
 clean:
 	rm -f ${ALSAROOT}/*.o

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+CC ?= gcc
+CFLAGS = -lasound
+ALSAROOT = pysynth/wrappers/midi/alsa
+
+# object files to generate
+OBJ = \
+      ${ALSAROOT}/midi_alsa.o
+
+all: ${OBJ} ${ALSAROOT}/midi_alsa.so
+
+${ALSAROOT}/midi_alsa.o: ${ALSAROOT}/midi_alsa.c
+	${CC} ${CFLAGS} -fPIC -c ${ALSAROOT}/midi_alsa.c -o ${ALSAROOT}/midi_alsa.o
+
+${ALSAROOT}/midi_alsa.so: ${OBJ}
+	${CC} ${CFLAGS} -shared -o ${ALSAROOT}/midi_alsa.so
+
+clean:
+	rm -f ${ALSAROOT}/*.o

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ${ALSAROOT}/midi_alsa.o: ${ALSAROOT}/midi_alsa.c
 	${CC} ${CFLAGS} -fPIC -c ${ALSAROOT}/midi_alsa.c -o ${ALSAROOT}/midi_alsa.o
 
 ${ALSAROOT}/midi_alsa.so: ${OBJ}
-	${CC} ${CFLAGS} -shared -o ${ALSAROOT}/midi_alsa.so
+	${CC} ${CFLAGS} -shared -o ${ALSAROOT}/midi_alsa.so ${OBJ}
 
 clean:
 	rm -f ${ALSAROOT}/*.o


### PR DESCRIPTION
you mentioned in the readme you hadn't worked out a way to build the C code yet, so I made a little Makefile that'll do it. you could also add any other build steps you want to it for python; I'm not familiar with it but I think there's ways to package it and whatnot. 

it is important to note that while I'm, like, *pretty sure* this will work, I'm not on linux, so it won't actually build because I obviously don't have ALSA. so if it doesn't work, I can help try to fix it, or you can just disregard this.